### PR TITLE
feat: EIP-712 signing for trade_open_eip712 and trade_close_eip712

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Connect it to Claude Desktop or Claude Code and trade with natural language.
 ### Perpetual Trading
 | Tool | Description |
 |---|---|
-| `trade_open` | Open a position with a market order. |
-| `trade_close` | Close an open position with a market order. |
+| `trade_open` | Open a position with a market order (Cosmos signing). |
+| `trade_close` | Close an open position with a market order (Cosmos signing). |
+| `trade_open_eip712` | Open a position using EIP-712 Ethereum signing (MetaMask-compatible keys). |
+| `trade_close_eip712` | Close a position using EIP-712 Ethereum signing (MetaMask-compatible keys). |
 | `trade_limit_open` | Open a limit order. |
 | `trade_limit_orders` | List open limit orders. |
 | `trade_limit_close` | Cancel a limit order by `orderHash`. |
@@ -147,7 +149,8 @@ MCP Server  (src/mcp/server.ts)
        ├── wallets/      Wallet generation and management
        ├── markets/      Market data with in-memory caching
        ├── accounts/     Balances and positions
-       ├── trading/      Perpetual market orders
+       ├── trading/      Perpetual market orders (Cosmos signing)
+       ├── evm/eip712    Perpetual market orders (EIP-712 signing)
        ├── orders/       Perpetual limit order lifecycle
        ├── transfers/    Bank transfers and subaccount moves
        ├── bridges/      Peggy + deBridge cross-chain

--- a/src/evm/eip712.test.ts
+++ b/src/evm/eip712.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for EIP-712 trading module.
+ * Network calls are mocked — no testnet required.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { testConfig } from '../test-utils/index.js'
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('../wallets/index.js', () => ({
+  wallets: {
+    unlock: vi.fn().mockReturnValue('0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'),
+  },
+}))
+
+vi.mock('../markets/index.js', () => ({
+  markets: {
+    resolve: vi.fn().mockResolvedValue({
+      marketId: '0xbtcmarket',
+      symbol: 'BTC',
+      tickSize: '1000',
+      minQuantityTick: '0.001',
+      maintenanceMarginRatio: '0.05',
+      oracleBase: 'BTC',
+      oracleQuote: 'USDT',
+      oracleType: 'bandibc',
+    }),
+    getPrice: vi.fn().mockResolvedValue({ toFixed: () => '50000', mul: (x: any) => ({ div: () => ({ toFixed: () => '0.002' }) }), eq: () => false, div: () => ({ toFixed: () => '0.002' }) }),
+  },
+}))
+
+vi.mock('../accounts/index.js', () => ({
+  accounts: {
+    getPositions: vi.fn().mockResolvedValue([{
+      symbol: 'BTC',
+      side: 'long',
+      quantity: '0.002',
+      entryPrice: '50000',
+      markPrice: '51000',
+      unrealizedPnl: '2',
+    }]),
+  },
+}))
+
+vi.mock('../client/index.js', () => ({
+  createClient: vi.fn().mockReturnValue({
+    derivativesApi: {
+      fetchOrderbookV2: vi.fn().mockResolvedValue({
+        sells: [{ price: '50500000000', quantity: '1' }],
+        buys: [{ price: '49500000000', quantity: '1' }],
+      }),
+    },
+    txApi: {
+      broadcast: vi.fn().mockResolvedValue({ code: 0, txHash: '0xabc123', rawLog: '' }),
+    },
+  }),
+}))
+
+vi.mock('@injectivelabs/sdk-ts', async () => {
+  const actual = await vi.importActual('@injectivelabs/sdk-ts') as Record<string, unknown>
+  return {
+    ...actual,
+    MsgCreateDerivativeMarketOrder: {
+      fromJSON: vi.fn().mockReturnValue({ toAmino: () => ({}) }),
+    },
+    getEip712TypedData: vi.fn().mockReturnValue({
+      domain: { name: 'Injective', version: '1.0', chainId: '0x6f0' },
+      types: {
+        EIP712Domain: [{ name: 'name', type: 'string' }],
+        MsgValue: [{ name: 'market_id', type: 'string' }],
+      },
+      primaryType: 'MsgValue',
+      message: { market_id: '0xbtcmarket' },
+    }),
+    createTxRawEIP712: vi.fn().mockReturnValue({ signatures: [] }),
+    createWeb3Extension: vi.fn().mockReturnValue({}),
+    createTransaction: vi.fn().mockReturnValue({ txRaw: {} }),
+    ChainRestAuthApi: vi.fn().mockImplementation(() => ({
+      fetchAccount: vi.fn().mockResolvedValue({
+        account: {
+          base_account: {
+            account_number: '42',
+            sequence: '7',
+            pub_key: { key: 'AAAA' },
+          },
+        },
+      }),
+    })),
+    ChainRestTendermintApi: vi.fn().mockImplementation(() => ({
+      fetchLatestBlock: vi.fn().mockResolvedValue({
+        header: { height: '12345678' },
+      }),
+    })),
+    Address: {
+      fromHex: vi.fn().mockReturnValue({
+        getSubaccountId: vi.fn().mockReturnValue('0xsub000'),
+      }),
+    },
+    OrderTypeMap: { BUY: 1, SELL: 2 },
+    SIGN_AMINO: 1,
+  }
+})
+
+vi.mock('ethers', async () => {
+  const actual = await vi.importActual('ethers') as Record<string, unknown>
+  return {
+    ...actual,
+    Wallet: vi.fn().mockImplementation(() => ({
+      address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      signTypedData: vi.fn().mockResolvedValue(
+        '0x' + 'ab'.repeat(65)
+      ),
+    })),
+  }
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('eip712', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('eip712.open', () => {
+    it('returns txHash and trade details on success', async () => {
+      const { eip712 } = await import('./eip712.js')
+      const result = await eip712.open(testConfig(), {
+        address: 'inj1' + 'a'.repeat(38),
+        password: 'testpass',
+        symbol: 'BTC',
+        side: 'long',
+        amount: '100',
+        leverage: 10,
+      })
+
+      expect(result.txHash).toBe('0xabc123')
+      expect(result).toHaveProperty('executionPrice')
+      expect(result).toHaveProperty('quantity')
+      expect(result).toHaveProperty('margin')
+      expect(result).toHaveProperty('liquidationPrice')
+    })
+
+    it('signs with ethers.Wallet.signTypedData', async () => {
+      const { Wallet } = await import('ethers')
+      const { eip712 } = await import('./eip712.js')
+
+      await eip712.open(testConfig(), {
+        address: 'inj1' + 'a'.repeat(38),
+        password: 'testpass',
+        symbol: 'BTC',
+        side: 'long',
+        amount: '100',
+      })
+
+      const walletInstance = vi.mocked(Wallet).mock.results[0]?.value
+      expect(walletInstance?.signTypedData).toHaveBeenCalled()
+      // EIP712Domain must be stripped from types passed to signTypedData
+      const [_domain, types] = walletInstance?.signTypedData.mock.calls[0]
+      expect(types).not.toHaveProperty('EIP712Domain')
+    })
+
+    it('throws BroadcastFailed when chain returns non-zero code', async () => {
+      const { createClient } = await import('../client/index.js')
+      vi.mocked(createClient).mockReturnValueOnce({
+        derivativesApi: {
+          fetchOrderbookV2: vi.fn().mockResolvedValue({
+            sells: [{ price: '50500000000', quantity: '1' }],
+            buys: [],
+          }),
+        },
+        txApi: {
+          broadcast: vi.fn().mockResolvedValue({ code: 12, txHash: '', rawLog: 'insufficient funds' }),
+        },
+      } as any)
+
+      const { eip712 } = await import('./eip712.js')
+      await expect(
+        eip712.open(testConfig(), {
+          address: 'inj1' + 'a'.repeat(38),
+          password: 'testpass',
+          symbol: 'BTC',
+          side: 'long',
+          amount: '100',
+        })
+      ).rejects.toThrow('broadcast failed')
+    })
+
+    it('throws NoLiquidity when orderbook is empty', async () => {
+      const { createClient } = await import('../client/index.js')
+      vi.mocked(createClient).mockReturnValueOnce({
+        derivativesApi: {
+          fetchOrderbookV2: vi.fn().mockResolvedValue({ sells: [], buys: [] }),
+        },
+        txApi: { broadcast: vi.fn() },
+      } as any)
+
+      const { eip712 } = await import('./eip712.js')
+      await expect(
+        eip712.open(testConfig(), {
+          address: 'inj1' + 'a'.repeat(38),
+          password: 'testpass',
+          symbol: 'BTC',
+          side: 'long',
+          amount: '100',
+        })
+      ).rejects.toThrow('no liquidity')
+    })
+  })
+
+  describe('eip712.close', () => {
+    it('returns txHash and close details on success', async () => {
+      const { eip712 } = await import('./eip712.js')
+      const result = await eip712.close(testConfig(), {
+        address: 'inj1' + 'a'.repeat(38),
+        password: 'testpass',
+        symbol: 'BTC',
+      })
+
+      expect(result.txHash).toBe('0xabc123')
+      expect(result).toHaveProperty('closedQty')
+      expect(result).toHaveProperty('exitPrice')
+      expect(result).toHaveProperty('realizedPnl')
+    })
+
+    it('throws NoPositionFound when no open position exists', async () => {
+      const { accounts } = await import('../accounts/index.js')
+      vi.mocked(accounts.getPositions).mockResolvedValueOnce([])
+
+      const { eip712 } = await import('./eip712.js')
+      await expect(
+        eip712.close(testConfig(), {
+          address: 'inj1' + 'a'.repeat(38),
+          password: 'testpass',
+          symbol: 'ETH',
+        })
+      ).rejects.toThrow('No open position found')
+    })
+
+    it('strips EIP712Domain from types before signing', async () => {
+      const { Wallet } = await import('ethers')
+      const { eip712 } = await import('./eip712.js')
+
+      await eip712.close(testConfig(), {
+        address: 'inj1' + 'a'.repeat(38),
+        password: 'testpass',
+        symbol: 'BTC',
+      })
+
+      const walletInstance = vi.mocked(Wallet).mock.results[0]?.value
+      const [_domain, types] = walletInstance?.signTypedData.mock.calls[0]
+      expect(types).not.toHaveProperty('EIP712Domain')
+      expect(types).toHaveProperty('MsgValue')
+    })
+  })
+})

--- a/src/evm/eip712.ts
+++ b/src/evm/eip712.ts
@@ -1,0 +1,382 @@
+/**
+ * EIP-712 trading module — open and close perpetual positions using
+ * Ethereum-style signing (EIP-712 / eth_signTypedData_v4).
+ *
+ * This mirrors the MetaMask signing flow used in browser frontends, but runs
+ * entirely server-side using ethers.js Wallet.signTypedData(). Users whose
+ * private keys are Ethereum-format (MetaMask exports, hardware wallets, etc.)
+ * can use these tools instead of the standard Cosmos-signed trade_open/close.
+ *
+ * Signing flow:
+ *   1. Decrypt private key from keystore
+ *   2. Build MsgCreateDerivativeMarketOrder
+ *   3. Generate EIP-712 typed data via getEip712TypedData
+ *   4. Sign with ethers.Wallet.signTypedData (equivalent to MetaMask eth_signTypedData_v4)
+ *   5. Assemble TxRaw with EIP-712 extension + web3 extension
+ *   6. Broadcast via TxGrpcApi
+ */
+import Decimal from 'decimal.js'
+import { Wallet } from 'ethers'
+import {
+  MsgCreateDerivativeMarketOrder,
+  OrderTypeMap,
+  Address,
+  getEip712TypedData,
+  createTxRawEIP712,
+  createWeb3Extension,
+  createTransaction,
+  SIGN_AMINO,
+  ChainRestAuthApi,
+  ChainRestTendermintApi,
+} from '@injectivelabs/sdk-ts'
+import type { EvmChainId } from '@injectivelabs/ts-types'
+import { Config } from '../config/index.js'
+import { wallets } from '../wallets/index.js'
+import { markets } from '../markets/index.js'
+import { accounts } from '../accounts/index.js'
+import { createClient } from '../client/index.js'
+import { BroadcastFailed, NoLiquidity, NoPositionFound, QuantityTooSmall } from '../errors/index.js'
+import {
+  walkOrderbook,
+  applySlippage,
+  calcMargin,
+  calcLiquidationPrice,
+  quantize,
+} from '../trading/math.js'
+
+const USDT_DECIMALS = 6
+const QUOTE_SCALE = new Decimal(10).pow(USDT_DECIMALS)
+const TIMEOUT_BLOCKS = 20
+
+const DEFAULT_LEVERAGE = 10
+const DEFAULT_OPEN_SLIPPAGE = 0.01
+const DEFAULT_CLOSE_SLIPPAGE = 0.05
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function fromChainPrice(chainPrice: Decimal): Decimal {
+  return chainPrice.div(QUOTE_SCALE)
+}
+
+function toChainPrice(humanPrice: Decimal, tickSize: Decimal): string {
+  return quantize(humanPrice.mul(QUOTE_SCALE), tickSize).toFixed(0)
+}
+
+function toChainQuantity(humanQty: Decimal, tickSize: Decimal): string {
+  const q = quantize(humanQty, tickSize)
+  return q.toFixed(18).replace(/\.?0+$/, '') || '0'
+}
+
+function usdtToBase(amount: Decimal): string {
+  return amount.mul(QUOTE_SCALE).toFixed(0)
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+/** Placeholder pubkey for new accounts whose pubkey isn't yet on-chain. */
+function ethereumPubkeyPlaceholder(): string {
+  return btoa(String.fromCharCode(...new Uint8Array(33)))
+}
+
+async function getAccountDetails(restEndpoint: string, injAddress: string) {
+  const authApi = new ChainRestAuthApi(restEndpoint)
+  const account = await authApi.fetchAccount(injAddress)
+  const base = account.account.base_account
+  return {
+    accountNumber: parseInt(base.account_number, 10),
+    sequence: parseInt(base.sequence, 10),
+    pubKey: base.pub_key?.key ?? '',
+  }
+}
+
+async function getTimeoutHeight(restEndpoint: string): Promise<number> {
+  const tendermintApi = new ChainRestTendermintApi(restEndpoint)
+  const block = await tendermintApi.fetchLatestBlock()
+  return parseInt(block.header.height, 10) + TIMEOUT_BLOCKS
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface Eip712OpenParams {
+  address: string
+  password: string
+  symbol: string
+  side: 'long' | 'short'
+  /** Notional amount in USDT */
+  amount: number | string
+  leverage?: number
+  slippage?: number
+}
+
+export interface Eip712OpenResult {
+  txHash: string
+  executionPrice: string
+  quantity: string
+  margin: string
+  liquidationPrice: string
+}
+
+export interface Eip712CloseParams {
+  address: string
+  password: string
+  symbol: string
+  slippage?: number
+}
+
+export interface Eip712CloseResult {
+  txHash: string
+  closedQty: string
+  exitPrice: string
+  realizedPnl: string
+}
+
+// ─── Core ─────────────────────────────────────────────────────────────────────
+
+export const eip712 = {
+  async open(config: Config, params: Eip712OpenParams): Promise<Eip712OpenResult> {
+    const {
+      address,
+      password,
+      symbol,
+      side,
+      leverage = DEFAULT_LEVERAGE,
+      slippage = DEFAULT_OPEN_SLIPPAGE,
+    } = params
+    const notional = new Decimal(params.amount)
+    const leverageDec = new Decimal(leverage)
+    const slippageDec = new Decimal(slippage)
+
+    // 1. Decrypt key and derive Ethereum address + subaccount
+    const privateKeyHex = wallets.unlock(address, password)
+    const ethWallet = new Wallet(privateKeyHex.startsWith('0x') ? privateKeyHex : `0x${privateKeyHex}`)
+    const subaccountId = Address.fromHex(ethWallet.address).getSubaccountId(0)
+
+    // 2. Resolve market
+    const market = await markets.resolve(config, symbol)
+
+    // 3. Oracle price + orderbook
+    const oraclePrice = await markets.getPrice(config, market.marketId)
+    const client = createClient(config)
+    const orderbook = await client.derivativesApi.fetchOrderbookV2(market.marketId)
+
+    const isBuy = side === 'long'
+    const levels = isBuy ? (orderbook.sells ?? []) : (orderbook.buys ?? [])
+    if (levels.length === 0) throw new NoLiquidity(market.marketId)
+
+    const orderbookLevels = levels.map(l => ({
+      price: fromChainPrice(new Decimal(l.price)),
+      quantity: new Decimal(l.quantity),
+    }))
+
+    const worstFillPrice = walkOrderbook(orderbookLevels, notional)
+    const executionPrice = worstFillPrice.eq(0) ? oraclePrice : worstFillPrice
+    const priceWithSlippage = applySlippage(executionPrice, slippageDec, side)
+
+    // 4. Quantize price + quantity
+    const tickSize = new Decimal(market.tickSize)
+    const qtyTickSize = new Decimal(market.minQuantityTick)
+    const chainPrice = toChainPrice(priceWithSlippage, tickSize)
+    const humanQty = notional.div(executionPrice)
+    const chainQty = toChainQuantity(humanQty, qtyTickSize)
+    if (chainQty === '0') throw new QuantityTooSmall(market.minQuantityTick)
+
+    const marginHuman = calcMargin(priceWithSlippage, humanQty, leverageDec)
+    const chainMargin = usdtToBase(marginHuman)
+
+    // 5. Build message
+    const msg = MsgCreateDerivativeMarketOrder.fromJSON({
+      marketId: market.marketId,
+      subaccountId,
+      injectiveAddress: address,
+      orderType: isBuy ? OrderTypeMap.BUY : OrderTypeMap.SELL,
+      price: chainPrice,
+      margin: chainMargin,
+      quantity: chainQty,
+      feeRecipient: address,
+    })
+
+    // 6. Account state + block height (parallel)
+    const [acct, timeoutHeight] = await Promise.all([
+      getAccountDetails(config.endpoints.rest, address),
+      getTimeoutHeight(config.endpoints.rest),
+    ])
+
+    // 7. Generate EIP-712 typed data
+    const typedData = getEip712TypedData({
+      msgs: msg,
+      tx: {
+        accountNumber: acct.accountNumber.toString(),
+        sequence: acct.sequence.toString(),
+        timeoutHeight: timeoutHeight.toString(),
+        chainId: config.chainId,
+        memo: `open ${side} ${symbol}`,
+      },
+      evmChainId: config.ethereumChainId as unknown as EvmChainId,
+    }) as { domain: Record<string, unknown>; types: Record<string, unknown[]>; message: Record<string, unknown> }
+
+    // 8. Sign — ethers.signTypedData requires EIP712Domain stripped from types
+    const { EIP712Domain: _ignored, ...signingTypes } = typedData.types
+    const sig = await ethWallet.signTypedData(
+      typedData.domain as Parameters<Wallet['signTypedData']>[0],
+      signingTypes as Parameters<Wallet['signTypedData']>[1],
+      typedData.message,
+    )
+
+    // 9. Assemble TxRaw with EIP-712 extension and broadcast
+    const { txRaw } = createTransaction({
+      message: msg,
+      memo: `open ${side} ${symbol}`,
+      pubKey: acct.pubKey || ethereumPubkeyPlaceholder(),
+      sequence: acct.sequence,
+      accountNumber: acct.accountNumber,
+      chainId: config.chainId,
+      timeoutHeight,
+      signMode: SIGN_AMINO,
+    })
+
+    const web3Extension = createWeb3Extension({
+      evmChainId: config.ethereumChainId as unknown as EvmChainId,
+    })
+    const txRawEip712 = createTxRawEIP712(txRaw, web3Extension)
+    txRawEip712.signatures = [hexToBytes(sig)]
+
+    const response = await client.txApi.broadcast(txRawEip712)
+    if (response.code !== 0) {
+      throw new BroadcastFailed(`code ${response.code}: ${response.rawLog}`)
+    }
+
+    const maintenanceMarginRatio = new Decimal(market.maintenanceMarginRatio)
+    const liqPrice = calcLiquidationPrice(executionPrice, leverageDec, maintenanceMarginRatio, side)
+
+    return {
+      txHash: response.txHash,
+      executionPrice: executionPrice.toFixed(6),
+      quantity: humanQty.toFixed(6),
+      margin: marginHuman.toFixed(6),
+      liquidationPrice: liqPrice.toFixed(6),
+    }
+  },
+
+  async close(config: Config, params: Eip712CloseParams): Promise<Eip712CloseResult> {
+    const {
+      address,
+      password,
+      symbol,
+      slippage = DEFAULT_CLOSE_SLIPPAGE,
+    } = params
+    const slippageDec = new Decimal(slippage)
+
+    // 1. Decrypt key and derive Ethereum address + subaccount
+    const privateKeyHex = wallets.unlock(address, password)
+    const ethWallet = new Wallet(privateKeyHex.startsWith('0x') ? privateKeyHex : `0x${privateKeyHex}`)
+    const subaccountId = Address.fromHex(ethWallet.address).getSubaccountId(0)
+
+    // 2. Find open position
+    const openPositions = await accounts.getPositions(config, address)
+    const position = openPositions.find(p => p.symbol.toUpperCase() === symbol.toUpperCase())
+    if (!position) throw new NoPositionFound(symbol)
+
+    // 3. Resolve market + orderbook
+    const market = await markets.resolve(config, symbol)
+    const client = createClient(config)
+    const orderbook = await client.derivativesApi.fetchOrderbookV2(market.marketId)
+
+    const isClosingLong = position.side === 'long'
+    const closeSide: 'long' | 'short' = isClosingLong ? 'short' : 'long'
+    const levels = isClosingLong ? (orderbook.buys ?? []) : (orderbook.sells ?? [])
+    if (levels.length === 0) throw new NoLiquidity(market.marketId)
+
+    const orderbookLevels = levels.map(l => ({
+      price: fromChainPrice(new Decimal(l.price)),
+      quantity: new Decimal(l.quantity),
+    }))
+
+    const positionQty = new Decimal(position.quantity)
+    const positionNotional = positionQty.mul(new Decimal(position.markPrice))
+    const worstFillPrice = walkOrderbook(orderbookLevels, positionNotional)
+    const exitPrice = worstFillPrice.eq(0) ? new Decimal(position.markPrice) : worstFillPrice
+    const exitPriceWithSlippage = applySlippage(exitPrice, slippageDec, closeSide)
+
+    const tickSize = new Decimal(market.tickSize)
+    const qtyTickSize = new Decimal(market.minQuantityTick)
+    const chainPrice = toChainPrice(exitPriceWithSlippage, tickSize)
+    const chainQty = toChainQuantity(positionQty, qtyTickSize)
+    if (chainQty === '0') throw new QuantityTooSmall(market.minQuantityTick)
+
+    // Reduce-only close — no new margin posted
+    const msg = MsgCreateDerivativeMarketOrder.fromJSON({
+      marketId: market.marketId,
+      subaccountId,
+      injectiveAddress: address,
+      orderType: isClosingLong ? OrderTypeMap.SELL : OrderTypeMap.BUY,
+      price: chainPrice,
+      margin: '0',
+      quantity: chainQty,
+      feeRecipient: address,
+    })
+
+    const [acct, timeoutHeight] = await Promise.all([
+      getAccountDetails(config.endpoints.rest, address),
+      getTimeoutHeight(config.endpoints.rest),
+    ])
+
+    const typedData = getEip712TypedData({
+      msgs: msg,
+      tx: {
+        accountNumber: acct.accountNumber.toString(),
+        sequence: acct.sequence.toString(),
+        timeoutHeight: timeoutHeight.toString(),
+        chainId: config.chainId,
+        memo: `close ${symbol}`,
+      },
+      evmChainId: config.ethereumChainId as unknown as EvmChainId,
+    }) as { domain: Record<string, unknown>; types: Record<string, unknown[]>; message: Record<string, unknown> }
+
+    const { EIP712Domain: _ignored, ...signingTypes } = typedData.types
+    const sig = await ethWallet.signTypedData(
+      typedData.domain as Parameters<Wallet['signTypedData']>[0],
+      signingTypes as Parameters<Wallet['signTypedData']>[1],
+      typedData.message,
+    )
+
+    const { txRaw } = createTransaction({
+      message: msg,
+      memo: `close ${symbol}`,
+      pubKey: acct.pubKey || ethereumPubkeyPlaceholder(),
+      sequence: acct.sequence,
+      accountNumber: acct.accountNumber,
+      chainId: config.chainId,
+      timeoutHeight,
+      signMode: SIGN_AMINO,
+    })
+
+    const web3Extension = createWeb3Extension({
+      evmChainId: config.ethereumChainId as unknown as EvmChainId,
+    })
+    const txRawEip712 = createTxRawEIP712(txRaw, web3Extension)
+    txRawEip712.signatures = [hexToBytes(sig)]
+
+    const response = await client.txApi.broadcast(txRawEip712)
+    if (response.code !== 0) {
+      throw new BroadcastFailed(`code ${response.code}: ${response.rawLog}`)
+    }
+
+    const entryPrice = new Decimal(position.entryPrice)
+    const direction = position.side === 'long' ? 1 : -1
+    const realizedPnl = exitPriceWithSlippage.minus(entryPrice).mul(positionQty).mul(direction)
+
+    return {
+      txHash: response.txHash,
+      closedQty: positionQty.toFixed(6),
+      exitPrice: exitPriceWithSlippage.toFixed(6),
+      realizedPnl: realizedPnl.toFixed(6),
+    }
+  },
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,4 +33,7 @@ export type { DeBridgeQuoteParams, DeBridgeQuoteResult, DeBridgeSendParams, DeBr
 export { evm } from './evm/index.js'
 export type { EvmAccount, BroadcastEvmTxParams, BroadcastEvmTxResult } from './evm/index.js'
 
+export { eip712 } from './evm/eip712.js'
+export type { Eip712OpenParams, Eip712OpenResult, Eip712CloseParams, Eip712CloseResult } from './evm/eip712.js'
+
 export * from './errors/index.js'

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,6 +23,7 @@ import { transfers } from '../transfers/index.js'
 import { bridges } from '../bridges/index.js'
 import { debridge } from '../bridges/debridge.js'
 import { evm } from '../evm/index.js'
+import { eip712 } from '../evm/eip712.js'
 
 const injAddress = z.string().regex(/^inj1[a-z0-9]{38}$/, 'Must be a valid inj1... address (42 chars)')
 const numericString = z.string().regex(/^\d+(\.\d+)?$/, 'Must be a positive numeric string')
@@ -609,6 +610,60 @@ server.tool(
       chainId,
       memo,
     })
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(result, null, 2),
+      }],
+    }
+  },
+)
+
+// ─── EIP-712 Trading Tools ────────────────────────────────────────────────────
+
+server.tool(
+  'trade_open_eip712',
+  'Open a perpetual futures position using EIP-712 Ethereum-style signing. ' +
+  'Use this instead of trade_open if your wallet key is an Ethereum private key ' +
+  '(e.g. exported from MetaMask or a hardware wallet). ' +
+  'IMPORTANT: Real on-chain transaction with real funds. Confirm parameters with the user first.',
+  {
+    address: injAddress.describe('Sender inj1... address (must be in local keystore).'),
+    password: z.string().describe('Keystore password to decrypt the private key.'),
+    symbol: z.string().min(1).describe('Market ticker, e.g. "BTC", "ETH", "INJ".'),
+    side: z.enum(['long', 'short']).describe('Position direction.'),
+    amount: numericString.describe('Notional size in USDT, e.g. "100" = $100.'),
+    leverage: z.number().int().min(1).max(50).optional()
+      .describe('Leverage multiplier (default: 10).'),
+    slippage: z.number().min(0).max(0.5).optional()
+      .describe('Slippage tolerance as a fraction (default: 0.01 = 1%).'),
+  },
+  async ({ address, password, symbol, side, amount, leverage, slippage }) => {
+    const result = await eip712.open(config, { address, password, symbol, side, amount, leverage, slippage })
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(result, null, 2),
+      }],
+    }
+  },
+)
+
+server.tool(
+  'trade_close_eip712',
+  'Close an open perpetual position using EIP-712 Ethereum-style signing. ' +
+  'Use this instead of trade_close if your wallet key is an Ethereum private key ' +
+  '(e.g. exported from MetaMask or a hardware wallet). ' +
+  'IMPORTANT: Real on-chain transaction. Confirm with the user before calling.',
+  {
+    address: injAddress.describe('Sender inj1... address (must be in local keystore).'),
+    password: z.string().describe('Keystore password to decrypt the private key.'),
+    symbol: z.string().min(1).describe('Market ticker of the position to close, e.g. "BTC".'),
+    slippage: z.number().min(0).max(0.5).optional()
+      .describe('Slippage tolerance as a fraction (default: 0.05 = 5%).'),
+  },
+  async ({ address, password, symbol, slippage }) => {
+    const result = await eip712.close(config, { address, password, symbol, slippage })
     return {
       content: [{
         type: 'text',


### PR DESCRIPTION
## Summary

Adds EIP-712 Ethereum-style signing as an alternative to the existing Cosmos signing path, enabling users with MetaMask-format private keys (including hardware wallet exports from Ledger/Trezor) to trade without conversion.

- **`trade_open_eip712`** — open a perpetual position using EIP-712 signing
- **`trade_close_eip712`** — close a perpetual position using EIP-712 signing

### How it works

The signing flow mirrors what browser frontends do via MetaMask's `eth_signTypedData_v4`, but runs server-side using `ethers.Wallet.signTypedData()`:

1. Decrypt private key from keystore → create `ethers.Wallet`
2. Fetch oracle price + orderbook, apply slippage, quantize tick sizes
3. Build `MsgCreateDerivativeMarketOrder`
4. Generate EIP-712 typed data via `getEip712TypedData`
5. Sign with `ethers.Wallet.signTypedData` (strips `EIP712Domain` from types as ethers v6 requires)
6. Assemble `TxRaw` with `createTxRawEIP712` + `createWeb3Extension`
7. Broadcast via `TxGrpcApi`

### When to use which tool

| Situation | Use |
|---|---|
| Key imported as Injective/Cosmos mnemonic | `trade_open` / `trade_close` |
| Key exported from MetaMask / hardware wallet (hex) | `trade_open_eip712` / `trade_close_eip712` |

Both tools accept the same parameters and return the same result shape.

## Files

- `src/evm/eip712.ts` — core EIP-712 signing module (new)
- `src/evm/eip712.test.ts` — 7 unit tests (new)
- `src/mcp/server.ts` — 2 new tools registered
- `src/index.ts` — exports for `eip712` and its types
- `README.md` — updated tool table and architecture diagram

## Test plan

- [x] `npm run typecheck` — passes clean
- [x] `npm test` — 269/269 tests pass
- [ ] Integration test against testnet with a MetaMask-exported key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EIP-712 Ethereum-style signing support for perpetual trading positions
  * New trading tools available: trade_open_eip712 and trade_close_eip712 for opening and closing positions with EIP-712 signing

* **Tests**
  * Comprehensive test coverage added for EIP-712 trading functionality

* **Documentation**
  * Architecture documentation updated to reflect EIP-712 and Cosmos signing options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->