### PR TITLE
feat: add authz_grant and authz_revoke MCP tools

### DIFF
--- a/src/authz/index.ts
+++ b/src/authz/index.ts
@@ -1,0 +1,151 @@
+/**
+ * AuthZ module — grant and revoke Cosmos SDK authorizations.
+ *
+ * Allows one address (granter) to delegate specific message types to another
+ * address (grantee) so the grantee can execute those messages on behalf of the
+ * granter via MsgExec — without requiring the granter to sign each transaction.
+ *
+ * Primary use-case: grant an agent/bot wallet trading permissions so it can
+ * execute orders on your behalf without needing your key per-trade.
+ */
+import {
+  MsgGrant,
+  MsgRevoke,
+  getGenericAuthorizationFromMessageType,
+} from '@injectivelabs/sdk-ts'
+import { Config } from '../config/index.js'
+import { wallets } from '../wallets/index.js'
+import { createBroadcaster } from '../client/index.js'
+import { BroadcastFailed } from '../errors/index.js'
+
+/** Default trading message types covered by a grant. */
+export const TRADING_MSG_TYPES = [
+  '/injective.exchange.v1beta1.MsgCreateDerivativeMarketOrder',
+  '/injective.exchange.v1beta1.MsgCreateDerivativeLimitOrder',
+  '/injective.exchange.v1beta1.MsgCancelDerivativeOrder',
+  '/injective.exchange.v1beta1.MsgBatchUpdateOrders',
+  '/injective.exchange.v1beta1.MsgIncreasePositionMargin',
+  '/injective.exchange.v1beta1.MsgCreateSpotMarketOrder',
+  '/injective.exchange.v1beta1.MsgCreateSpotLimitOrder',
+  '/injective.exchange.v1beta1.MsgCancelSpotOrder',
+]
+
+/** Default grant duration: 30 days. */
+const DEFAULT_EXPIRY_S = 60 * 60 * 24 * 30
+
+export interface GrantParams {
+  /** Granter address (must be in local keystore). */
+  granterAddress: string
+  /** Keystore password for the granter. */
+  password: string
+  /** Grantee address (who will be allowed to execute on behalf of granter). */
+  granteeAddress: string
+  /** Message types to grant. Defaults to all TRADING_MSG_TYPES. */
+  msgTypes?: string[]
+  /** Grant validity in seconds from now. Default: 30 days. */
+  expirySeconds?: number
+}
+
+export interface GrantResult {
+  txHash: string
+  granter: string
+  grantee: string
+  msgTypes: string[]
+  expiresAt: string
+}
+
+export interface RevokeParams {
+  /** Granter address (must be in local keystore). */
+  granterAddress: string
+  /** Keystore password for the granter. */
+  password: string
+  /** Grantee address whose permissions will be revoked. */
+  granteeAddress: string
+  /** Message types to revoke. Defaults to all TRADING_MSG_TYPES. */
+  msgTypes?: string[]
+}
+
+export interface RevokeResult {
+  txHash: string
+  granter: string
+  grantee: string
+  msgTypes: string[]
+}
+
+export const authz = {
+  async grant(config: Config, params: GrantParams): Promise<GrantResult> {
+    const {
+      granterAddress,
+      password,
+      granteeAddress,
+      msgTypes = TRADING_MSG_TYPES,
+      expirySeconds = DEFAULT_EXPIRY_S,
+    } = params
+
+    const privateKeyHex = wallets.unlock(granterAddress, password)
+    const expiration = Math.floor(Date.now() / 1000) + expirySeconds
+
+    const msgs = msgTypes.map(msgType =>
+      MsgGrant.fromJSON({
+        granter:       granterAddress,
+        grantee:       granteeAddress,
+        authorization: getGenericAuthorizationFromMessageType(msgType),
+        expiration,
+      })
+    )
+
+    const broadcaster = createBroadcaster(config, privateKeyHex)
+    let txHash: string
+    try {
+      const response = await broadcaster.broadcast({ msgs, memo: 'authz grant' })
+      txHash = response.txHash
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new BroadcastFailed(message)
+    }
+
+    return {
+      txHash,
+      granter:   granterAddress,
+      grantee:   granteeAddress,
+      msgTypes,
+      expiresAt: new Date(expiration * 1000).toISOString(),
+    }
+  },
+
+  async revoke(config: Config, params: RevokeParams): Promise<RevokeResult> {
+    const {
+      granterAddress,
+      password,
+      granteeAddress,
+      msgTypes = TRADING_MSG_TYPES,
+    } = params
+
+    const privateKeyHex = wallets.unlock(granterAddress, password)
+
+    const msgs = msgTypes.map(msgType =>
+      MsgRevoke.fromJSON({
+        granter:     granterAddress,
+        grantee:     granteeAddress,
+        messageType: msgType,
+      })
+    )
+
+    const broadcaster = createBroadcaster(config, privateKeyHex)
+    let txHash: string
+    try {
+      const response = await broadcaster.broadcast({ msgs, memo: 'authz revoke' })
+      txHash = response.txHash
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new BroadcastFailed(message)
+    }
+
+    return {
+      txHash,
+      granter:  granterAddress,
+      grantee:  granteeAddress,
+      msgTypes,
+    }
+  },
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,6 +24,7 @@ import { bridges } from '../bridges/index.js'
 import { debridge } from '../bridges/debridge.js'
 import { evm } from '../evm/index.js'
 import { eip712 } from '../evm/eip712.js'
+import { authz, TRADING_MSG_TYPES } from '../authz/index.js'
 
 const injAddress = z.string().regex(/^inj1[a-z0-9]{38}$/, 'Must be a valid inj1... address (42 chars)')
 const numericString = z.string().regex(/^\d+(\.\d+)?$/, 'Must be a positive numeric string')
@@ -664,6 +665,61 @@ server.tool(
   },
   async ({ address, password, symbol, slippage }) => {
     const result = await eip712.close(config, { address, password, symbol, slippage })
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(result, null, 2),
+      }],
+    }
+  },
+)
+
+// ─── AuthZ Tools ─────────────────────────────────────────────────────────────
+
+server.tool(
+  'authz_grant',
+  'Grant another Injective address permission to execute trading messages on your behalf ' +
+  '(Cosmos SDK AuthZ). After granting, the grantee can submit trades using authz_exec-style ' +
+  'flows without requiring your signature per transaction. ' +
+  'IMPORTANT: This is a real on-chain transaction. Confirm parameters with the user first. ' +
+  `Default message types covered: ${TRADING_MSG_TYPES.join(', ')}`,
+  {
+    granterAddress: injAddress.describe('Your inj1... address (granter — must be in local keystore).'),
+    password: z.string().describe('Keystore password to decrypt the granter private key.'),
+    granteeAddress: injAddress.describe('The inj1... address being granted permissions (grantee).'),
+    msgTypes: z.array(z.string().min(1)).optional()
+      .describe('Message type URLs to grant. Omit to use all default trading types.'),
+    expirySeconds: z.number().int().positive().optional()
+      .describe('Grant validity in seconds from now. Default: 2592000 (30 days).'),
+  },
+  async ({ granterAddress, password, granteeAddress, msgTypes, expirySeconds }) => {
+    const result = await authz.grant(config, {
+      granterAddress, password, granteeAddress, msgTypes, expirySeconds,
+    })
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(result, null, 2),
+      }],
+    }
+  },
+)
+
+server.tool(
+  'authz_revoke',
+  'Revoke previously granted trading permissions from a grantee address. ' +
+  'IMPORTANT: This is a real on-chain transaction. Confirm parameters with the user first.',
+  {
+    granterAddress: injAddress.describe('Your inj1... address (granter — must be in local keystore).'),
+    password: z.string().describe('Keystore password to decrypt the granter private key.'),
+    granteeAddress: injAddress.describe('The inj1... address whose permissions will be revoked.'),
+    msgTypes: z.array(z.string().min(1)).optional()
+      .describe('Message type URLs to revoke. Omit to revoke all default trading types.'),
+  },
+  async ({ granterAddress, password, granteeAddress, msgTypes }) => {
+    const result = await authz.revoke(config, {
+      granterAddress, password, granteeAddress, msgTypes,
+    })
     return {
       content: [{
         type: 'text',


### PR DESCRIPTION
## Summary

- Adds `src/authz/index.ts` with `grant()` and `revoke()` functions wrapping Cosmos SDK `MsgGrant` / `MsgRevoke`
- New `authz_grant` MCP tool: grants a grantee address permission to execute trading messages on behalf of the granter — configurable message types and expiry (default 30 days)
- New `authz_revoke` MCP tool: revokes previously granted permissions
- Default covered message types: derivative + spot market/limit orders, cancel, batch update, increase margin

## Use case

Enables AI agent workflows where a bot wallet is granted trading permissions once, then executes trades autonomously via `MsgExec` without requiring the granter's signature per transaction.

## Test plan

- [ ] `authz_grant` broadcasts a valid `MsgGrant` tx on testnet
- [ ] `authz_revoke` broadcasts a valid `MsgRevoke` tx on testnet
- [ ] Custom `msgTypes` array is respected
- [ ] Custom `expirySeconds` is respected
- [ ] Wrong password returns a keystore error (not a broadcast error)
- [ ] Build passes: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authorization management capabilities enabling you to grant and revoke message-type permissions to other addresses
  * New authz_grant tool: Grant trading permissions with optional message type filtering and custom expiry settings
  * New authz_revoke tool: Revoke previously granted permissions for specified addresses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->