### PR TITLE
chore: replace deprecated inEVM terminology with Injective EVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Connect it to Claude Desktop or Claude Code and trade with natural language.
 ### EVM
 | Tool | Description |
 |---|---|
-| `evm_broadcast` | Broadcast a raw EVM transaction on Injective inEVM. |
+| `evm_broadcast` | Broadcast a raw EVM transaction on Injective EVM. |
 
 ---
 
@@ -154,7 +154,7 @@ MCP Server  (src/mcp/server.ts)
        ├── orders/       Perpetual limit order lifecycle
        ├── transfers/    Bank transfers and subaccount moves
        ├── bridges/      Peggy + deBridge cross-chain
-       └── evm/          Generic Injective inEVM tx broadcasting
+       └── evm/          Generic Injective EVM tx broadcasting
               │
               ▼
      Injective Chain
@@ -194,7 +194,7 @@ All Injective denom formats are supported:
 | Peggy (bridged ERC-20) | `peggy0x...` | USDT |
 | IBC | `ibc/...` | ATOM |
 | TokenFactory | `factory/inj.../name` | — |
-| MTS / inEVM ERC-20 | `erc20:0x...` | inEVM tokens |
+| MTS / Injective EVM ERC-20 | `erc20:0x...` | Injective EVM tokens |
 
 Token metadata (symbol, decimals) is resolved automatically against on-chain registry and cached for the lifetime of the server process.
 

--- a/src/evm/index.ts
+++ b/src/evm/index.ts
@@ -1,5 +1,5 @@
 /**
- * EVM module — generic transaction and encoding helpers for Injective inEVM.
+ * EVM module — generic transaction and encoding helpers for Injective EVM.
  *
  * This module is bridge-agnostic and can be reused by deBridge, LayerZero, or
  * any future EVM contract interactions.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -661,7 +661,7 @@ server.tool(
 
 server.tool(
   'evm_broadcast',
-  'Broadcast a raw EVM transaction on Injective inEVM. ' +
+  'Broadcast a raw EVM transaction on Injective EVM. ' +
   'IMPORTANT: Real on-chain transaction with real funds. Confirm parameters first.',
   {
     address: injAddress.describe('Sender inj1... address (must be in local keystore).'),


### PR DESCRIPTION
Update all user-facing strings and comments to use the current product name "Injective EVM" instead of the deprecated "inEVM".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized terminology throughout documentation and user-facing descriptions by updating "inEVM" references to "EVM" for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->