### PR TITLE
fix: funds-safety bugs in inbound bridge and close flows

### DIFF
--- a/src/bridges/debridge.ts
+++ b/src/bridges/debridge.ts
@@ -374,6 +374,11 @@ export interface DeBridgeInboundQuoteParams {
   srcTokenAddress: string
   /** Human-readable amount of source token (e.g. "10.5"). */
   amount: string
+  /**
+   * Decimals of the source ERC20 token. Defaults to 6 (USDC/USDT).
+   * Must be set correctly for non-6-decimal tokens (e.g. 18 for WETH).
+   */
+  srcTokenDecimals?: number
   /** Destination ERC20 token address on Injective EVM. */
   dstTokenAddress: string
   /** Recipient address on Injective (bech32 inj1... or 0x EVM address). */
@@ -463,10 +468,7 @@ export async function getQuoteInbound(
   }
   const recipientEvm = resolveRecipientToEvm(params.recipient)
 
-  // USDC on Arbitrum has 6 decimals; generalise by detecting from the API response.
-  // For the quote we need base units — assume 6 decimals if unknown (USDC/USDT standard).
-  // The estimation response confirms decimals so users can verify.
-  const srcAmountBase = toBaseUnits(amount, 6).toString()
+  const srcAmountBase = toBaseUnits(amount, params.srcTokenDecimals ?? 6).toString()
 
   const url = buildInboundCreateTxUrl({
     srcChainId,
@@ -517,8 +519,7 @@ export async function sendBridgeInbound(
   const srcAuthorityAddress = params.srcAuthorityAddress ?? senderEvmAddress
   const dstAuthorityAddress = params.dstAuthorityAddress ?? recipientEvm
 
-  // USDC/USDT use 6 decimals — read from estimation if available.
-  const srcAmountBase = toBaseUnits(amount, 6).toString()
+  const srcAmountBase = toBaseUnits(amount, params.srcTokenDecimals ?? 6).toString()
 
   // 1. Fetch the full order calldata from deBridge.
   const url = buildInboundCreateTxUrl({

--- a/src/evm/eip712.ts
+++ b/src/evm/eip712.ts
@@ -59,7 +59,7 @@ function fromChainPrice(chainPrice: Decimal): Decimal {
 }
 
 function toChainPrice(humanPrice: Decimal, tickSize: Decimal): string {
-  return quantize(humanPrice.mul(QUOTE_SCALE), tickSize).toFixed(0)
+  return quantize(humanPrice.mul(QUOTE_SCALE), tickSize).toFixed(0, Decimal.ROUND_DOWN)
 }
 
 function toChainQuantity(humanQty: Decimal, tickSize: Decimal): string {
@@ -68,7 +68,7 @@ function toChainQuantity(humanQty: Decimal, tickSize: Decimal): string {
 }
 
 function usdtToBase(amount: Decimal): string {
-  return amount.mul(QUOTE_SCALE).toFixed(0)
+  return amount.mul(QUOTE_SCALE).toFixed(0, Decimal.ROUND_DOWN)
 }
 
 function hexToBytes(hex: string): Uint8Array {
@@ -273,15 +273,15 @@ export const eip712 = {
     } = params
     const slippageDec = new Decimal(slippage)
 
-    // 1. Decrypt key and derive Ethereum address + subaccount
+    // 1. Decrypt key
     const privateKeyHex = wallets.unlock(address, password)
     const ethWallet = new Wallet(privateKeyHex.startsWith('0x') ? privateKeyHex : `0x${privateKeyHex}`)
-    const subaccountId = Address.fromHex(ethWallet.address).getSubaccountId(0)
 
-    // 2. Find open position
+    // 2. Find open position — use its actual subaccountId, not hardcoded index 0
     const openPositions = await accounts.getPositions(config, address)
     const position = openPositions.find(p => p.symbol.toUpperCase() === symbol.toUpperCase())
     if (!position) throw new NoPositionFound(symbol)
+    const subaccountId = position.subaccountId
 
     // 3. Resolve market + orderbook
     const market = await markets.resolve(config, symbol)

--- a/src/orders/index.ts
+++ b/src/orders/index.ts
@@ -131,7 +131,7 @@ function parseNonNegativeDecimal(name: string, value: string): Decimal {
 
 function toChainPrice(price: Decimal, tickSize: Decimal): string {
   const chainPrice = price.mul(QUOTE_SCALE)
-  return quantize(chainPrice, tickSize).toFixed(0)
+  return quantize(chainPrice, tickSize).toFixed(0, Decimal.ROUND_DOWN)
 }
 
 function toChainQuantity(quantity: Decimal, tickSize: Decimal): string {
@@ -140,7 +140,7 @@ function toChainQuantity(quantity: Decimal, tickSize: Decimal): string {
 }
 
 function usdtToBase(amount: Decimal): string {
-  return amount.mul(QUOTE_SCALE).toFixed(0)
+  return amount.mul(QUOTE_SCALE).toFixed(0, Decimal.ROUND_DOWN)
 }
 
 function fromChainPrice(raw: string): string {

--- a/src/trading/index.ts
+++ b/src/trading/index.ts
@@ -75,7 +75,7 @@ function fromChainPrice(chainPrice: Decimal): Decimal {
 function toChainPrice(humanPrice: Decimal, tickSize: Decimal): string {
   const chainPrice = humanPrice.mul(QUOTE_SCALE)
   const quantized = quantize(chainPrice, tickSize)
-  return quantized.toFixed(0)
+  return quantized.toFixed(0, Decimal.ROUND_DOWN)
 }
 
 /** Scale a human quantity to chain units using the market's quantity tick size. */
@@ -86,7 +86,7 @@ function toChainQuantity(humanQty: Decimal, tickSize: Decimal): string {
 
 /** Convert USDT amount string to base units (×10^6). */
 function usdtToBase(amount: Decimal): string {
-  return amount.mul(new Decimal(10).pow(USDT_DECIMALS)).toFixed(0)
+  return amount.mul(new Decimal(10).pow(USDT_DECIMALS)).toFixed(0, Decimal.ROUND_DOWN)
 }
 
 export const trading = {
@@ -264,8 +264,7 @@ export const trading = {
     // Reduce-only close order — no new margin posted
     const chainMargin = '0'
 
-    const pk = PrivateKey.fromHex(privateKeyHex)
-    const subaccountId = pk.toAddress().getSubaccountId(0)
+    const subaccountId = position.subaccountId
 
     const msg = MsgCreateDerivativeMarketOrder.fromJSON({
       marketId: market.marketId,

--- a/src/utils/denom-math.ts
+++ b/src/utils/denom-math.ts
@@ -9,5 +9,5 @@ import Decimal from 'decimal.js'
  * e.g. "1.5" with 18 decimals → "1500000000000000000"
  */
 export function toBaseUnits(humanAmount: Decimal, decimals: number): string {
-  return humanAmount.mul(new Decimal(10).pow(decimals)).toFixed(0)
+  return humanAmount.mul(new Decimal(10).pow(decimals)).toFixed(0, Decimal.ROUND_DOWN)
 }


### PR DESCRIPTION
## Summary

Fixes three funds-safety bugs reported in #9:

- **Bug 1 — Hardcoded 6 decimals for inbound bridge src token**: `getQuoteInbound` and `sendBridgeInbound` hardcoded `10^6` for all source tokens. Added `srcTokenDecimals?: number` to `DeBridgeInboundQuoteParams` (defaults to `6` for USDC/USDT). Callers must set this for non-6-decimal tokens (e.g. `18` for WETH).

- **Bug 2 — Close flows always target subaccount 0**: Both `trading/index.ts` and `evm/eip712.ts` derived the subaccount via `pk.toAddress().getSubaccountId(0)`, which always returns index 0 regardless of which subaccount actually holds the position. Fixed to use `position.subaccountId` from the fetched position record.

- **Bug 3 — Base-unit conversion rounds instead of truncating**: `toBaseUnits` in `utils/denom-math.ts` used `toFixed(0)` (default `ROUND_HALF_UP`). All chain amount conversions — margin, price, quantity — now use `Decimal.ROUND_DOWN` to truncate, preventing the chain from rejecting orders where the submitted amount is a fraction of a base unit above what was intended.

## Files changed

- `src/utils/denom-math.ts` — `ROUND_DOWN` in `toBaseUnits`
- `src/bridges/debridge.ts` — `srcTokenDecimals` param + `ROUND_DOWN`
- `src/trading/index.ts` — `position.subaccountId` + `ROUND_DOWN`
- `src/evm/eip712.ts` — `position.subaccountId` + `ROUND_DOWN`
- `src/orders/index.ts` — `ROUND_DOWN`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted decimal handling in bridge operations for improved token amount accuracy.
  * Modified price and amount calculation rounding to use truncation, ensuring more conservative conversions.
  * Improved subaccount resolution for open and close trading operations by deriving from position data rather than wallet address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->