### PR TITLE
feat: add x402_fetch tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ Connect it to Claude Desktop or Claude Code and trade with natural language.
 | `account_positions` | Get open perpetual positions with unrealized P&L. |
 | `token_metadata` | Look up symbol, decimals, and type for any denom. |
 
+### x402 Payments
+| Tool | Description |
+|---|---|
+| `x402_fetch` | Fetch an x402-gated API endpoint, automatically signing and paying the required USDC quote using the Injective EVM wallet if a 402 is returned. |
+
 ### Native USDC and CCTP
 | Tool | Description |
 |---|---|

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@injectivelabs/networks": "^1.14.27",
         "@injectivelabs/sdk-ts": "^1.14.27",
         "@injectivelabs/utils": "^1.14.27",
+        "@injectivelabs/x402": "^0.0.1",
         "@modelcontextprotocol/sdk": "^1.0.4",
         "decimal.js": "^10.4.3",
         "zod": "^3.22.0"
@@ -748,6 +749,27 @@
         "bignumber.js": "^9.3.1",
         "http-status-codes": "^2.3.0",
         "store2": "^2.14.4"
+      }
+    },
+    "node_modules/@injectivelabs/x402": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/x402/-/x402-0.0.1.tgz",
+      "integrity": "sha512-uHxTHz/bsX3kvIYPLXC/x0pZ6jcluRqowGLbXsEuFlVeG7rDNUXimrbNScnhRqZcPkMfjEHtMwiRuCOP6Kau4A==",
+      "license": "MIT",
+      "dependencies": {
+        "viem": "^2.39.3",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "express": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@injectivelabs/networks": "^1.14.27",
     "@injectivelabs/sdk-ts": "^1.14.27",
     "@injectivelabs/utils": "^1.14.27",
+    "@injectivelabs/x402": "^0.0.1",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "decimal.js": "^10.4.3",
     "zod": "^3.22.0"

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -29,6 +29,7 @@ import { authz, TRADING_MSG_TYPES } from '../authz/index.js'
 import { usdc } from '../usdc/index.js'
 import { rfq } from '../rfq/index.js'
 import { frontendGuidanceTopics, guidance } from '../guidance/index.js'
+import { createInjectiveClient } from '@injectivelabs/x402/client'
 
 const injAddress = z.string().regex(INJ_ADDRESS_RE, 'Must be a valid inj1... address (42 chars)')
 const numericString = z.string().regex(/^\d+(\.\d+)?$/, 'Must be a positive numeric string')
@@ -982,6 +983,44 @@ server.tool(
       content: [{
         type: 'text',
         text: JSON.stringify(result, null, 2),
+      }],
+    }
+  },
+)
+
+// ─── x402 Payment Tools ────────────────────────────────────────────────────────
+
+server.tool(
+  'x402_fetch',
+  'Fetch data from an x402-gated API endpoint. Automatically handles 402 Payment Required ' +
+  'responses by signing a USDC payment using the Injective EVM wallet, submitting it to the facilitator, ' +
+  'and retrying the request. IMPORTANT: Real on-chain payment with real funds.',
+  {
+    address: injAddress.describe('The inj1... address of your trading wallet.'),
+    password: z.string().describe('Keystore password to decrypt the private key for signing.'),
+    url: z.string().url().describe('The URL of the x402-gated API endpoint.'),
+  },
+  async ({ address, password, url }) => {
+    const privateKeyHex = wallets.unlock(address, password)
+    const client = createInjectiveClient({ privateKey: privateKeyHex as `0x${string}` })
+    const response = await client.fetch(url)
+    
+    const text = await response.text()
+    let data;
+    try {
+      data = JSON.parse(text)
+    } catch {
+      data = text
+    }
+
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          status: response.status,
+          url: response.url,
+          data
+        }, null, 2),
       }],
     }
   },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -997,7 +997,7 @@ server.tool(
   'and retrying the request. IMPORTANT: Real on-chain payment with real funds.',
   {
     address: injAddress.describe('The inj1... address of your trading wallet.'),
-    password: z.string().describe('Keystore password to decrypt the private key for signing.'),
+    password: z.string().describe('Keystore password to decrypt the private key for signing. SECURITY: Never log, store, or echo this. Use secret inputs only.'),
     url: z.string().url().describe('The URL of the x402-gated API endpoint.'),
   },
   async ({ address, password, url }) => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -29,7 +29,7 @@ import { authz, TRADING_MSG_TYPES } from '../authz/index.js'
 import { usdc } from '../usdc/index.js'
 import { rfq } from '../rfq/index.js'
 import { frontendGuidanceTopics, guidance } from '../guidance/index.js'
-import { createInjectiveClient } from '@injectivelabs/x402/client'
+import { createInjectiveClient as x402CreateClient, parsePaymentRequired } from '@injectivelabs/x402/client'
 
 const injAddress = z.string().regex(INJ_ADDRESS_RE, 'Must be a valid inj1... address (42 chars)')
 const numericString = z.string().regex(/^\d+(\.\d+)?$/, 'Must be a positive numeric string')
@@ -999,11 +999,33 @@ server.tool(
     address: injAddress.describe('The inj1... address of your trading wallet.'),
     password: z.string().describe('Keystore password to decrypt the private key for signing. SECURITY: Never log, store, or echo this. Use secret inputs only.'),
     url: z.string().url().describe('The URL of the x402-gated API endpoint.'),
+    maxAmount: z.number().optional().describe('A safety limit on the maximum USDC amount you are willing to pay for this request.'),
   },
-  async ({ address, password, url }) => {
+  async ({ address, password, url, maxAmount }) => {
     const privateKeyHex = wallets.unlock(address, password)
-    const client = createInjectiveClient({ privateKey: privateKeyHex as `0x${string}` })
-    const response = await client.fetch(url)
+    
+    if (maxAmount !== undefined) {
+      const preflight = await fetch(url)
+      if (preflight.status === 402) {
+        const authHeader = preflight.headers.get('WWW-Authenticate') || preflight.headers.get('402-Payment-Required')
+        if (authHeader) {
+          const required = parsePaymentRequired(authHeader)
+          if (required.accepts && required.accepts.length > 0) {
+            // USDC is 6 decimals. We compare decimal representations or convert string to number.
+            // Amount is usually a string representing the smallest unit (e.g. 500000 = 0.5 USDC).
+            const rawAmount = Number(required.accepts[0].amount)
+            const tokenDecimals = 6 // USDC
+            const usdAmount = rawAmount / Math.pow(10, tokenDecimals)
+            if (usdAmount > maxAmount) {
+              throw new Error(`Payment required (${usdAmount} USDC) exceeds your maxAmount safety limit of ${maxAmount} USDC.`)
+            }
+          }
+        }
+      }
+    }
+
+    const x402Client = x402CreateClient({ privateKey: privateKeyHex as `0x${string}` })
+    const response = await x402Client.fetch(url)
     
     const text = await response.text()
     let data;


### PR DESCRIPTION
## Overview
   This PR adds native x402 payment capabilities to the Injective MCP server, allowing AI agents to fetch gated API
  endpoints and seamlessly pay the `402 Payment Required` invoice using their local keystore.

 ## Changes Made
   * **Dependency Added:** Installed `@injectivelabs/x402` to utilize the `createInjectiveClient` HTTP wrapper.
   * **New MCP Tool:** Added the `x402_fetch` tool to `src/mcp/server.ts`.

 ## How it Works
   When an agent calls `x402_fetch(address, password, url)`:
    1. The server decrypts the local EVM private key.
    2. It initiates a fetch request to the gated endpoint.
    3. If the server responds with a 402 and a price quote, the client automatically signs an EIP-3009 USDC
  authorization.
    4. The signed payment is submitted to the x402 facilitator to settle on Injective EVM.
    5. The original request is retried with the payment receipt, successfully returning the underlying data back to
  the AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new tool for accessing payment-gated web resources directly from the app.
  * The tool can automatically handle payment-required responses and retry the request after approval.
  * Responses now return the request status, destination URL, and retrieved content in a readable format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->