### PR TITLE
Add frontend trading guidance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Connect it to Claude Desktop or Claude Code and trade with natural language.
 | `rfq_constants` | Return RFQ contract, gateway, websocket, chain IDs, and default quote collection window for the configured network. |
 | `rfq_market_readiness` | List active derivative markets and mark which ones match the RFQ quote denom. Read-only. |
 
+### Frontend Guidance
+| Tool | Description |
+|---|---|
+| `frontend_guidance_topics` | List read-only frontend guidance topics available from the MCP server. |
+| `frontend_guidance` | Return guidance for Injective browser trading flows, optionally filtered by topic. |
+
 ### Perpetual Trading
 | Tool | Description |
 |---|---|
@@ -168,6 +174,14 @@ For RFQ discovery:
 > Which active USDC perp markets are RFQ-ready?
 ```
 
+For frontend implementation guidance:
+
+```text
+> List Injective frontend guidance topics
+> Show frontend guidance for native USDC balance UX
+> What should I check before shipping an Injective browser wallet signing flow?
+```
+
 ---
 
 ## Architecture
@@ -186,6 +200,7 @@ MCP Server  (src/mcp/server.ts)
        ├── accounts/     Balances and positions
        ├── usdc/         Native USDC metadata and Circle CCTP helpers
        ├── rfq/          RFQ constants and market readiness
+       ├── guidance/     Read-only frontend implementation guidance
        ├── trading/      Perpetual market orders (Cosmos signing)
        ├── evm/eip712    Perpetual market orders (EIP-712 signing)
        ├── orders/       Perpetual limit order lifecycle

--- a/src/guidance/guidance.test.ts
+++ b/src/guidance/guidance.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { frontendGuidanceTopics, getFrontendGuidance, listFrontendGuidanceTopics } from './index.js'
+
+describe('frontend guidance', () => {
+  it('lists all supported topics', () => {
+    expect(frontendGuidanceTopics).toEqual([
+      'wallet-signing',
+      'trading-ux',
+      'rfq-taker-ux',
+      'usdc-balance-ux',
+      'authz-autosign-readiness',
+    ])
+
+    const topics = listFrontendGuidanceTopics()
+    expect(topics).toHaveLength(frontendGuidanceTopics.length)
+    expect(topics.map((topic) => topic.topic)).toEqual(frontendGuidanceTopics)
+  })
+
+  it('returns all guidance when no topic is provided', () => {
+    const sections = getFrontendGuidance()
+
+    expect(sections).toHaveLength(frontendGuidanceTopics.length)
+    expect(sections.every((section) => section.checks.length > 0)).toBe(true)
+    expect(sections.every((section) => section.avoid.length > 0)).toBe(true)
+  })
+
+  it('filters guidance by topic', () => {
+    const sections = getFrontendGuidance('wallet-signing')
+
+    expect(sections).toHaveLength(1)
+    expect(sections[0]?.topic).toBe('wallet-signing')
+    expect(sections[0]?.checks.join(' ')).toContain('/injective.crypto.v1beta1.ethsecp256k1.PubKey')
+  })
+
+  it('includes native USDC identifiers in the USDC guidance', () => {
+    const [section] = getFrontendGuidance('usdc-balance-ux')
+    const text = `${section?.checks.join(' ')} ${section?.avoid.join(' ')}`
+
+    expect(text).toContain('0xa00C59fF5a080D2b954d0c75e46E22a0c371235a')
+    expect(text).toContain('erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a')
+  })
+
+  it('keeps AuthZ readiness guidance tied to grant and wallet identity checks', () => {
+    const [section] = getFrontendGuidance('authz-autosign-readiness')
+    const text = section?.checks.join(' ') ?? ''
+
+    expect(text).toContain('active granter inj1 address')
+    expect(text).toContain('granter address')
+    expect(text).toContain('MsgRevoke')
+  })
+})

--- a/src/guidance/index.ts
+++ b/src/guidance/index.ts
@@ -1,0 +1,160 @@
+export const frontendGuidanceTopics = [
+  'wallet-signing',
+  'trading-ux',
+  'rfq-taker-ux',
+  'usdc-balance-ux',
+  'authz-autosign-readiness',
+] as const
+
+export type FrontendGuidanceTopic = typeof frontendGuidanceTopics[number]
+
+export interface FrontendGuidanceSection {
+  topic: FrontendGuidanceTopic
+  title: string
+  summary: string
+  checks: string[]
+  avoid: string[]
+  relatedTools: string[]
+}
+
+const sections: FrontendGuidanceSection[] = [
+  {
+    topic: 'wallet-signing',
+    title: 'Injective browser wallet signing',
+    summary: 'Use Injective account and public key handling for browser transaction flows. Generic Cosmos signing code often reaches signing and then fails CheckTx on Injective EthAccount accounts.',
+    checks: [
+      'Query account metadata from LCD before signing and handle /injective.types.v1beta1.EthAccount explicitly.',
+      'Use base_account.account_number and base_account.sequence from the Injective account payload.',
+      'Ensure AuthInfo signer public key type URL is /injective.crypto.v1beta1.ethsecp256k1.PubKey.',
+      'Sign the same authInfoBytes that will be broadcast, including the Injective public key type.',
+      'Use the wallet address returned for injective-1 and avoid substituting another chain account without conversion checks.',
+      'Keep raw CheckTx details in logs and show short user-facing recovery copy.',
+    ],
+    avoid: [
+      'Assuming an inj1 address means generic /cosmos.crypto.secp256k1.PubKey signing is valid.',
+      'Treating account sequence mismatch as a chain parameter issue before checking duplicate clicks, stale sequence, multiple tabs, or retries.',
+      'Showing account numbers, sequences, signer internals, or raw CheckTx logs in the primary UI.',
+    ],
+    relatedTools: [
+      'address_normalize',
+      'account_balances',
+      'trade_open',
+      'trade_close',
+      'trade_open_eip712',
+      'trade_close_eip712',
+    ],
+  },
+  {
+    topic: 'trading-ux',
+    title: 'Injective trading frontend UX',
+    summary: 'Keep trading UIs precise in code and logs, but conservative and simple for users. Prevent duplicate submissions across open, close, cancel, cash-out, and emergency flows.',
+    checks: [
+      'Use one in-flight transaction lock per active wallet or session for all transaction-producing controls.',
+      'Disable every trade button while the lock is held and release only after confirmation or failure.',
+      'Keep bulk close and cash-out flows sequential unless signer and sequence management are proven safe for parallel broadcasts.',
+      'Prefer market search that scrolls to and highlights matching markets while keeping the grid stable.',
+      'Use stable card and grid dimensions so loading, error, and search states do not reshape trading forms.',
+      'Use short primary copy such as Enter cash, Need cash, Order pending, or Order failed, please try again.',
+    ],
+    avoid: [
+      'Relying on per-card spinners or per-position loading state to prevent duplicate broadcasts.',
+      'Filtering a market grid down to one stretched card when a search matches.',
+      'Using protocol internals as primary UI copy.',
+    ],
+    relatedTools: [
+      'market_list',
+      'market_price',
+      'trade_open',
+      'trade_close',
+      'trade_limit_open',
+      'trade_limit_close',
+    ],
+  },
+  {
+    topic: 'rfq-taker-ux',
+    title: 'RFQ taker browser UX',
+    summary: 'RFQ browser taker flows need final click-time validation and serialized submission. A matched quote is not the same as a confirmed trade.',
+    checks: [
+      'Validate quote freshness, maker allowlists, slippage, and prepared RFQ input at final submit time.',
+      'Disable all trade buttons for the wallet while an open or close RFQ is in flight.',
+      'Release the in-flight lock only after the accept transaction is confirmed or the flow fails.',
+      'Log RFQ IDs, taker details, and quote diagnostics for developers.',
+      'Use scroll-and-highlight market search instead of filtering cards out of the grid.',
+    ],
+    avoid: [
+      'Treating prequote or warm RFQ requests as sufficient for final submission.',
+      'Letting parallel RFQ accepts from the same wallet race the account sequence.',
+      'Showing no-quote diagnostics like RFQ IDs or taker addresses in user-facing error copy.',
+    ],
+    relatedTools: [
+      'rfq_constants',
+      'rfq_market_readiness',
+    ],
+  },
+  {
+    topic: 'usdc-balance-ux',
+    title: 'Native USDC balance UX',
+    summary: 'Trading apps should display native USDC balances conservatively, especially after bridge or CCTP funding while indexers catch up.',
+    checks: [
+      'Default trade amount inputs blank instead of prefilled with a fixed stake.',
+      'Let explicit controls such as Half and All-In populate from the currently visible USDC balance.',
+      'Truncate displayed USDC balances instead of rounding up.',
+      'After bridge or CCTP mint, use a short-lived local balance floor only until authoritative balances catch up or the floor expires.',
+      'Keep native USDC denoms explicit in code and logs.',
+      'Use Injective EVM USDC 0xa00C59fF5a080D2b954d0c75e46E22a0c371235a and Cosmos denom erc20:0xa00C59fF5a080D2b954d0c75e46E22a0c371235a.',
+    ],
+    avoid: [
+      'Prefilling an amount that may exceed the wallet balance.',
+      'Rounding displayed balances up in a way that implies unavailable funds are spendable.',
+      'Mixing bridged USDC variants with native Injective USDC in funding or trading flows.',
+    ],
+    relatedTools: [
+      'usdc_native_info',
+      'cctp_supported_chains',
+      'cctp_attestation_status',
+      'cctp_mint',
+      'account_balances',
+      'subaccount_deposit',
+    ],
+  },
+  {
+    topic: 'authz-autosign-readiness',
+    title: 'AuthZ and autosign browser readiness',
+    summary: 'A connected wallet is not the same as a ready trading session. Browser apps must validate grants, grantee state, fee path, and active wallet identity.',
+    checks: [
+      'Revalidate local grantee or session state against the active granter inj1 address after connect, account swap, reload, and revoke.',
+      'Key local grantee or session storage by granter address.',
+      'Broadcast and confirm MsgRevoke before clearing local session state.',
+      'Use one in-flight trade lock for the active granter and grantee pair.',
+      'Use user-facing states such as Authorize wallet, Order pending, and Order failed, please try again.',
+    ],
+    avoid: [
+      'Letting a session from wallet A appear active for wallet B.',
+      'Clearing local revoke state before the on-chain revoke succeeds.',
+      'Showing sequence numbers, raw CheckTx logs, or tx internals in the primary UI.',
+    ],
+    relatedTools: [
+      'authz_grant',
+      'authz_revoke',
+      'trade_open',
+      'trade_close',
+    ],
+  },
+]
+
+export function listFrontendGuidanceTopics(): Pick<FrontendGuidanceSection, 'topic' | 'title' | 'summary'>[] {
+  return sections.map(({ topic, title, summary }) => ({ topic, title, summary }))
+}
+
+export function getFrontendGuidance(topic?: FrontendGuidanceTopic): FrontendGuidanceSection[] {
+  if (!topic) {
+    return sections
+  }
+
+  return sections.filter((section) => section.topic === topic)
+}
+
+export const guidance = {
+  listFrontendGuidanceTopics,
+  getFrontendGuidance,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,9 @@ export type { NativeUsdcInfo, CctpChain, SupportedCctpChains, CctpAttestationSta
 export { rfq } from './rfq/index.js'
 export type { RfqConstants, RfqMarketReadinessParams, RfqMarketReadinessItem, RfqMarketReadiness } from './rfq/index.js'
 
+export { guidance } from './guidance/index.js'
+export type { FrontendGuidanceTopic, FrontendGuidanceSection } from './guidance/index.js'
+
 export { trading } from './trading/index.js'
 export type { OpenParams, OpenResult, CloseParams, CloseResult } from './trading/index.js'
 

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
+import { frontendGuidanceTopics } from '../guidance/index.js'
 
 // ─── Zod Schema Tests ────────────────────────────────────────────────────────
 // These mirror the schemas defined in server.ts to verify validation behavior.
@@ -14,6 +15,7 @@ import { z } from 'zod'
 const injAddress = z.string().regex(/^inj1[a-z0-9]{38}$/, 'Must be a valid inj1... address (42 chars)')
 const numericString = z.string().regex(/^\d+(\.\d+)?$/, 'Must be a positive numeric string')
 const ethAddress = z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Must be a valid 0x... Ethereum address (42 chars)')
+const frontendGuidanceTopic = z.enum(frontendGuidanceTopics)
 
 describe('injAddress schema', () => {
   it('accepts valid inj1 address', () => {
@@ -119,6 +121,26 @@ describe('numericString schema', () => {
 
   it('rejects trailing dot', () => {
     expect(numericString.safeParse('5.').success).toBe(false)
+  })
+})
+
+describe('frontend_guidance parameter validation', () => {
+  const schema = z.object({
+    topic: frontendGuidanceTopic.optional(),
+  })
+
+  it('accepts an omitted topic', () => {
+    expect(schema.safeParse({}).success).toBe(true)
+  })
+
+  it('accepts every supported topic', () => {
+    for (const topic of frontendGuidanceTopics) {
+      expect(schema.safeParse({ topic }).success).toBe(true)
+    }
+  })
+
+  it('rejects unknown topics', () => {
+    expect(schema.safeParse({ topic: 'oracle-migration' }).success).toBe(false)
   })
 })
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,10 +28,12 @@ import { eip712 } from '../evm/eip712.js'
 import { authz, TRADING_MSG_TYPES } from '../authz/index.js'
 import { usdc } from '../usdc/index.js'
 import { rfq } from '../rfq/index.js'
+import { frontendGuidanceTopics, guidance } from '../guidance/index.js'
 
 const injAddress = z.string().regex(INJ_ADDRESS_RE, 'Must be a valid inj1... address (42 chars)')
 const numericString = z.string().regex(/^\d+(\.\d+)?$/, 'Must be a positive numeric string')
 const hexString = z.string().regex(/^0x([0-9a-fA-F]{2})+$/, 'Must be non-empty, even-length 0x-prefixed hex')
+const frontendGuidanceTopic = z.enum(frontendGuidanceTopics)
 
 const server = new McpServer({
   name: 'injective-agent',
@@ -356,6 +358,42 @@ server.tool(
   },
   async ({ quoteDenom, symbol }) => {
     const result = await rfq.marketReadiness(config, { quoteDenom, symbol })
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(result, null, 2),
+      }],
+    }
+  },
+)
+
+// ─── Frontend Guidance Tools ────────────────────────────────────────────────
+
+server.tool(
+  'frontend_guidance_topics',
+  'List read-only Injective frontend guidance topics available from this MCP server.',
+  {},
+  async () => {
+    const result = guidance.listFrontendGuidanceTopics()
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify(result, null, 2),
+      }],
+    }
+  },
+)
+
+server.tool(
+  'frontend_guidance',
+  'Return read-only guidance for building Injective browser trading flows. ' +
+  'Use this before changing wallet signing, RFQ taker UX, native USDC balance UX, AuthZ/autosign readiness, or trade submission UI.',
+  {
+    topic: frontendGuidanceTopic.optional()
+      .describe('Optional topic filter. Omit to return all frontend guidance topics.'),
+  },
+  async ({ topic }) => {
+    const result = guidance.getFrontendGuidance(topic)
     return {
       content: [{
         type: 'text',


### PR DESCRIPTION
## Summary
- add structured read-only guidance for Injective browser wallet signing, trading UX, RFQ taker UX, native USDC balance UX, and AuthZ/autosign readiness
- expose guidance through MCP tools: frontend_guidance_topics and frontend_guidance
- document the new tools in README and add unit coverage for guidance data and topic validation

## Validation
- npm run typecheck
- npm test
- npm run build
- git diff --check origin/main...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frontend guidance functionality with two new tools: one lists available guidance topics, the other retrieves detailed guidance on wallet signing, trading UX, native USDC balance handling, and other frontend implementation scenarios.

* **Documentation**
  * Updated README with comprehensive documentation and usage examples for the new frontend guidance tools.

* **Tests**
  * Added comprehensive test coverage for the frontend guidance module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->